### PR TITLE
change xdrip-js tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "author": "Paul Dickens",
   "license": "MIT",
   "dependencies": {
-    "xdrip-js": "thebookins/xdrip-js#latest"
+    "xdrip-js": "thebookins/xdrip-js#v1.1.0"
   }
 }


### PR DESCRIPTION
The commit changes the version of xdrip-js to the tag v1.1.0, rather than the branch `latest`, which may change.