### PR TITLE
make xdrip-js tag persistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "author": "Paul Dickens",
   "license": "MIT",
   "dependencies": {
-    "xdrip-js": "thebookins/xdrip-js#v1.1.0"
+    "xdrip-js": "thebookins/xdrip-js#latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "author": "Paul Dickens",
   "license": "MIT",
   "dependencies": {
-    "xdrip-js": "thebookins/xdrip-js#latest"
+    "xdrip-js": "thebookins/xdrip-js#v1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "global-install": "npm install && sudo npm install -g && sudo npm link && sudo npm link logger"
   },
   "dependencies": {
-    "xdrip-js": "thebookins/xdrip-js#latest"
+    "xdrip-js": "thebookins/xdrip-js#v1.1.0"
   },
   "bin": {
     "xdrip-get-entries": "./xdrip-get-entries.sh",


### PR DESCRIPTION
Better to use the xdrip-js tag `v1.1.0`, which is persistent, rather than the branch `latest` which may change in future.