### PR TITLE
Increase lower limit that triggers last two BG avg

### DIFF
--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -56,7 +56,7 @@ else
     da=$(bc <<< "0 - $da")
   fi
 
-  if [ "$da" -lt "45" -a "$da" -gt "6" ]; then
+  if [ "$da" -lt "45" -a "$da" -gt "15" ]; then
      echo "Before Average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=$glucose"
      glucose=$(bc <<< "($glucose + $lastGlucose)/2")
      dg=$(bc <<< "$glucose - $lastGlucose")


### PR DESCRIPTION
Increased from 6 to 15.

In my testing, I found that the averaging of BG was happening two frequently and sometimes watering down the trend / direction calculation to show flat when it should have really been 45.