### PR TITLE
Now calculates sensor unfiltered noise and includes in entry to Nightscout / Openaps

### DIFF
--- a/calc-noise.sh
+++ b/calc-noise.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+INPUT=${1:-"/var/log/openaps/g5.csv"}
+MAXRECORDS=8
+MINRECORDS=4
+XINCREMENT=10000
+yarr=( $(tail -$MAXRECORDS $INPUT | cut -d ',' -f2 ) )
+n=${#yarr[@]}
+
+# sod = sum of distances
+sod=0
+overallsod=0
+
+for (( i=1; i<$n; i++ ))
+do
+  y1=${yarr[$i]}
+  y2=${yarr[$i-1]}
+
+  sod=$(bc -l <<< "$sod + sqrt(($XINCREMENT)^2 + ($y1 - $y2)^2)")
+done  
+
+overallsod=$(bc -l <<< "sqrt((${yarr[$n-1]} - ${yarr[0]})^2 + ($XINCREMENT*($n - 1))^2)")
+
+if [ $(bc -l <<< "$sod == 0") -eq 1 ]; then
+  # assume no noise if no records
+  noise = 0
+else
+  noise=$(bc -l <<< "1 - ($overallsod/$sod)")
+fi
+echo $noise
+
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",
@@ -16,7 +16,8 @@
     "xdrip-get-entries": "./xdrip-get-entries.sh",
     "post-xdripAPS": "./post-xdripAPS.sh",
     "post-ns": "./post-ns.sh",
-    "calc-calibration": "./calc-calibration.sh"
+    "calc-calibration": "./calc-calibration.sh",
+    "calc-calibration": "./calc-noise.sh"
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -315,7 +315,7 @@ if [ ! -f "/var/log/openaps/g5.csv" ]; then
 fi
 
 
-# calculate noise and position it for updating the entry sent to NS and xdripAPS
+# calculate the noise and position it for updating the entry sent to NS and xdripAPS
 noise=$(./calc-noise.sh)
 
 noiseSend=0 # unknown


### PR DESCRIPTION
Noise is currently calculated based off the last 8 unfiltered values from the sensor. It uses a method that evaluates the "jumpiness" of the line made by the last 8 points. The closer to 0 is better. 1 is the worst theoretical noise level. Then this value is converted to Nightscout and Openaps's way of interpreting and dealing with noise as follows:
```
noise=$(./calc-noise.sh)
noiseSend=0 # unknown
if [ $(bc -l <<< "$noise < 0.5") -eq 1 ]; then
  noiseSend=1  # Clean
elif [ $(bc -l <<< "$noise < 0.6") -eq 1 ]; then
  noiseSend=2  # Light
elif [ $(bc -l <<< "$noise < 0.75") -eq 1 ]; then
  noiseSend=3  # Medium
elif [ $(bc -l <<< "$noise >= 0.75") -eq 1 ]; then
  noiseSend=4  # Heavy
fi
```
