### PR TITLE
Fix mmol calibration.

### DIFF
--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -145,7 +145,7 @@ if [ -z $meterbg ]; then
   meterbg=`jq -M '.[0] .glucose' $METERBG_NS_RAW`
   meterbg="${meterbg%\"}"
   meterbg="${meterbg#\"}"
-  if [ "$meterbgunits" == "mmol" ]; then
+  if [[ "$meterbgunits" == *"mmol"* ]]; then
     meterbg=$(bc <<< "($meterbg *18)/1")
   fi
   echo "meterbg from nightscout: $meterbg"


### PR DESCRIPTION
The variable has quotes around them and the bash script
doesn't match comparing the meterbgunit "mmol" with mmol.
Switch to check if meterbgunit contains the mmol substring instead.